### PR TITLE
Exclude both local and IDE generation of local test storage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,4 @@ storage_benchmark/android/local.properties
 storage_benchmark/android/gradlew
 
 # storage files during local tests
-*.gs
+**/*.gs


### PR DESCRIPTION
Previously, `*.gs` files were excluded in `.gitignore` which were generated as a result of running tests from within Visual Code. However, running `flutter test` from the command line generates files within the `test` directory hence the change from to `*.gs` to `**/*.gs` 