### PR TITLE
JSON decode string instead of empty map (fixes #23 #27)

### DIFF
--- a/lib/src/storage/io.dart
+++ b/lib/src/storage/io.dart
@@ -83,7 +83,7 @@ class StorageImpl {
     final content = await _file.readAsString()
       ..trim();
     subject.value =
-        json?.decode(content == "" ? {} : content) as Map<String, dynamic>;
+        json?.decode(content == "" ? "{}" : content) as Map<String, dynamic>;
   }
 
   Future<File> _getFile() async {


### PR DESCRIPTION
This fixes the following exception at startup:

```
'_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'String'
```

Code was mistakenly trying to JSON decode a Dart empty-map instead of a string containing `"{}"`.

There might be another bug somewhere else, because I think this occurs when your storage suddenly disappears. Not certain.