### PR TITLE
Fix can't be assigned to a variable of type 'Map<String, dynamic>' on Get ^5

### DIFF
--- a/lib/src/storage/io.dart
+++ b/lib/src/storage/io.dart
@@ -101,7 +101,7 @@ class StorageImpl {
         subject.value = {};
       } else {
         try {
-          subject.value = json.decode(content) as Map<String, dynamic>?;
+          subject.value = json.decode(content) as Map<String, dynamic>;
         } catch (e) {
           Get.log('Can not recover Corrupted box', isError: true);
           subject.value = {};


### PR DESCRIPTION
Error: A value of type 'Map<String, dynamic>?' can't be assigned to a variable of type 'Map<String, dynamic>' because 'Map<String, dynamic>?' is nullable and 'Map<String, dynamic>' isn't.
../…/storage/io.dart:104
 - 'Map' is from 'dart:core'.
          subject.value = json.decode(content) as Map<String, dynamic>?;