### PR TITLE
Fix UTF-8 decoding crash when GetStorage backup file is corrupted

### DIFF
--- a/lib/src/storage/io.dart
+++ b/lib/src/storage/io.dart
@@ -95,8 +95,12 @@ class StorageImpl {
       Get.log('Corrupted box, recovering backup file', isError: true);
       final _file = await _getFile(true);
 
-      final content = await _file.readAsString()
-        ..trim();
+      String content = '';
+      try {
+        content = (await _file.readAsString()).trim();
+      } catch (e) {
+        Get.log('Can not recover Corrupted box', isError: true);
+      }
 
       if (content.isEmpty) {
         subject.value = {};


### PR DESCRIPTION
### Problem

When `GetStorage.bak` becomes corrupted or contains random binary data (non-UTF-8), the app crashes with the following exception:

```
E flutter : [ERROR:flutter/runtime/[dart_vm_initializer.cc](http://dart_vm_initializer.cc/)(40)] Unhandled Exception: FileSystemException: Failed to decode data using encoding 'utf-8', path = '/data/user/0/com.example.app/app_flutter/GetStorage.bak'
```

### Root Cause

The current implementation attempts to decode the backup file as UTF-8 without any validation or error handling. When the file is corrupted (e.g., overwritten with random bytes), it throws an unhandled exception, causing the app to crash.

### Reproduction Steps

Run the following command to corrupt the GetStorage files:

```bash
adb shell "run-as com.example.app sh -c 'cd app_flutter && head -c 1024 /dev/urandom > GetStorage.gs && head -c 1024 /dev/urandom > GetStorage.bak'"
```

After corruption, any operation that reads the backup file will trigger the crash.
